### PR TITLE
Add news crawler skeleton

### DIFF
--- a/news_crawler/__init__.py
+++ b/news_crawler/__init__.py
@@ -1,0 +1,15 @@
+"""News crawler skeleton using Crawl4AI components."""
+
+from .fetcher import Fetcher, FetchResult
+from .interpreters import ArticleLinkInterpreter, ArticleInterpreter, ArticleInfo
+from .crawler import NewsCrawler, SitePoller
+
+__all__ = [
+    "Fetcher",
+    "FetchResult",
+    "ArticleLinkInterpreter",
+    "ArticleInterpreter",
+    "ArticleInfo",
+    "NewsCrawler",
+    "SitePoller",
+]

--- a/news_crawler/crawler.py
+++ b/news_crawler/crawler.py
@@ -1,0 +1,67 @@
+"""High level orchestration for crawling news sites."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+from .fetcher import Fetcher
+from .interpreters import ArticleLinkInterpreter, ArticleInterpreter, ArticleInfo
+
+
+class NewsCrawler:
+    """Crawl a news site and extract articles."""
+
+    def __init__(
+        self,
+        fetcher: Fetcher,
+        link_interpreter: ArticleLinkInterpreter,
+        article_interpreter: ArticleInterpreter,
+    ) -> None:
+        self.fetcher = fetcher
+        self.link_interpreter = link_interpreter
+        self.article_interpreter = article_interpreter
+
+    async def crawl(self, url: str, depth: int = 0) -> List[ArticleInfo]:
+        html_result = await self.fetcher.fetch(url)
+        links = await self.link_interpreter.extract_links(url, html_result.html)
+
+        articles: List[ArticleInfo] = []
+        for link in links:
+            article_html = await self.fetcher.fetch(link)
+            try:
+                articles.append(await self.article_interpreter.extract(link, article_html.html))
+            except ValueError:
+                # Not an article, maybe a section page
+                if depth == 0:
+                    articles.extend(await self.crawl(link, depth=1))
+        if depth == 0 and not articles:
+            raise RuntimeError("No articles discovered within one level of depth")
+        return articles
+
+
+class SitePoller:
+    """Periodically poll a news site for new articles."""
+
+    def __init__(self, crawler: NewsCrawler, interval: float = 300.0) -> None:
+        self.crawler = crawler
+        self.interval = interval
+        self._seen: set[str] = set()
+        self._running = False
+
+    async def start(self, url: str) -> None:
+        self._running = True
+        while self._running:
+            articles = await self.crawler.crawl(url)
+            for art in articles:
+                if art.url not in self._seen:
+                    self._seen.add(art.url)
+                    self.handle_new_article(art)
+            await asyncio.sleep(self.interval)
+
+    def stop(self) -> None:
+        self._running = False
+
+    def handle_new_article(self, article: ArticleInfo) -> None:
+        """Override to integrate with storage or downstream pipelines."""
+        print(f"New article: {article.title} ({article.date})")

--- a/news_crawler/fetcher.py
+++ b/news_crawler/fetcher.py
@@ -1,0 +1,32 @@
+"""HTML fetching utilities built on Crawl4AI."""
+
+from dataclasses import dataclass
+from typing import Optional, Any, Dict
+
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, CacheMode
+
+
+@dataclass
+class FetchResult:
+    """Container for fetched HTML and metadata."""
+
+    url: str
+    html: str
+    metadata: Dict[str, Any]
+
+
+class Fetcher:
+    """Thin wrapper around ``AsyncWebCrawler`` for retrieving HTML."""
+
+    def __init__(self, browser_config: Optional[BrowserConfig] | None = None) -> None:
+        self.browser_config = browser_config or BrowserConfig(headless=True)
+
+    async def fetch(self, url: str, run_config: Optional[CrawlerRunConfig] | None = None) -> FetchResult:
+        """Retrieve the given URL and return the cleaned HTML."""
+        run_cfg = run_config or CrawlerRunConfig(cache_mode=CacheMode.BYPASS)
+        async with AsyncWebCrawler(config=self.browser_config) as crawler:
+            result = await crawler.arun(url=url, config=run_cfg)
+        if not result.success:
+            raise RuntimeError(f"Failed to fetch {url}: {result.error_message}")
+        html = result.cleaned_html or result.html or ""
+        return FetchResult(url=result.url, html=html, metadata=result.metadata)

--- a/news_crawler/interpreters.py
+++ b/news_crawler/interpreters.py
@@ -1,0 +1,65 @@
+"""LLM-based interpreters for link discovery and article parsing."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+from crawl4ai import LLMExtractionStrategy, LLMConfig
+
+
+class LinkList(BaseModel):
+    """Schema for a list of article links."""
+
+    links: List[str] = Field(description="Absolute URLs of article pages")
+
+
+class ArticleInfo(BaseModel):
+    """Structured information extracted from an article."""
+
+    title: str = Field(description="Headline of the article")
+    date: Optional[str] = Field(default=None, description="Publication date if available")
+    description: Optional[str] = Field(default=None, description="Short description or summary")
+
+
+class ArticleLinkInterpreter:
+    """Use ``LLMExtractionStrategy`` to identify article links from HTML."""
+
+    def __init__(self, llm_config: LLMConfig) -> None:
+        self.strategy = LLMExtractionStrategy(
+            llm_config=llm_config,
+            schema=LinkList.model_json_schema(),
+            extraction_type="schema",
+            instruction=(
+                "Inspect the HTML and return a JSON list of absolute URLs that represent news articles."
+            ),
+        )
+        self.strategy.input_format = "html"
+
+    async def extract_links(self, url: str, html: str) -> List[str]:
+        results = self.strategy.extract(url=url, html_content=html)
+        if not results:
+            return []
+        data = results[0] if isinstance(results, list) else results
+        return data.get("links", [])
+
+
+class ArticleInterpreter:
+    """Extract structured article data using ``LLMExtractionStrategy``."""
+
+    def __init__(self, llm_config: LLMConfig) -> None:
+        self.strategy = LLMExtractionStrategy(
+            llm_config=llm_config,
+            schema=ArticleInfo.model_json_schema(),
+            extraction_type="schema",
+            instruction="Extract the title, publication date, and description from the article.",
+        )
+        self.strategy.input_format = "html"
+
+    async def extract(self, url: str, html: str) -> ArticleInfo:
+        result = self.strategy.extract(url=url, html_content=html)
+        if isinstance(result, list) and result:
+            return ArticleInfo(**result[0])
+        if isinstance(result, dict):
+            return ArticleInfo(**result)
+        raise ValueError("No article data extracted")


### PR DESCRIPTION
## Summary
- add a new `news_crawler` package with Crawl4AI-based components
- provide `Fetcher` wrapper around `AsyncWebCrawler`
- implement LLM-based link and article interpreters
- create `NewsCrawler` orchestration class and `SitePoller` helper

## Testing
- `python -m py_compile news_crawler/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68440ed3a72c832d9b3193bb214937a8