### PR TITLE
Enable recursive directory processing for main_splitter.py

### DIFF
--- a/final_chunks_output/file1/file_1_content/memory_file_1_content_sec1.md
+++ b/final_chunks_output/file1/file_1_content/memory_file_1_content_sec1.md
@@ -1,0 +1,15 @@
+---
+id: memory_file_1_content_sec1
+cluster: memory
+topic: file_1_content
+title: File 1 Content
+version_context: None
+outline_date: None
+section_hierarchy: ['Topic 1.1', 'Topic 1.2']
+keywords: ['Text', 'Topic']
+description:
+file_path: file1/file_1_content.md
+---
+
+## Topic 1.2
+Text for topic 1.2

--- a/final_chunks_output/projectA/guide/guide_content/memory_guide_content_sec1.md
+++ b/final_chunks_output/projectA/guide/guide_content/memory_guide_content_sec1.md
@@ -1,0 +1,17 @@
+---
+id: memory_guide_content_sec1
+cluster: memory
+topic: guide_content
+title: Guide Content
+version_context: None
+outline_date: None
+section_hierarchy: ['Intro']
+keywords: ['Detail', 'Guide', 'Intro']
+description:
+file_path: projectA/guide/guide_content.md
+---
+
+## Intro
+Guide intro text
+### Detail
+Detail text

--- a/final_chunks_output/projectA/notes/notes_content/memory_notes_content_sec1.md
+++ b/final_chunks_output/projectA/notes/notes_content/memory_notes_content_sec1.md
@@ -1,0 +1,15 @@
+---
+id: memory_notes_content_sec1
+cluster: memory
+topic: notes_content
+title: Notes Content
+version_context: None
+outline_date: None
+section_hierarchy: ['Note A']
+keywords: ['Note']
+description:
+file_path: projectA/notes/notes_content.md
+---
+
+## Note A
+Note A text

--- a/final_chunks_output/projectB/tutorial/tutorial_content/memory_tutorial_content_sec1.md
+++ b/final_chunks_output/projectB/tutorial/tutorial_content/memory_tutorial_content_sec1.md
@@ -1,0 +1,15 @@
+---
+id: memory_tutorial_content_sec1
+cluster: memory
+topic: tutorial_content
+title: Tutorial Content
+version_context: None
+outline_date: None
+section_hierarchy: ['Step 1']
+keywords: ['Step', 'Tutorial']
+description:
+file_path: projectB/tutorial/tutorial_content.md
+---
+
+## Step 1
+Tutorial step 1

--- a/test_docs_input_for_main_splitter_test/file1.md
+++ b/test_docs_input_for_main_splitter_test/file1.md
@@ -1,0 +1,5 @@
+# File 1 Content
+## Topic 1.1
+Text for topic 1.1
+## Topic 1.2
+Text for topic 1.2

--- a/test_docs_input_for_main_splitter_test/projectA/guide.md
+++ b/test_docs_input_for_main_splitter_test/projectA/guide.md
@@ -1,0 +1,5 @@
+# Guide Content
+## Intro
+Guide intro text
+### Detail
+Detail text

--- a/test_docs_input_for_main_splitter_test/projectA/notes.md
+++ b/test_docs_input_for_main_splitter_test/projectA/notes.md
@@ -1,0 +1,3 @@
+# Notes Content
+## Note A
+Note A text

--- a/test_docs_input_for_main_splitter_test/projectB/tutorial.md
+++ b/test_docs_input_for_main_splitter_test/projectB/tutorial.md
@@ -1,0 +1,3 @@
+# Tutorial Content
+## Step 1
+Tutorial step 1

--- a/topics_from_file_to_topic/file1/file_1_content.md
+++ b/topics_from_file_to_topic/file1/file_1_content.md
@@ -1,0 +1,5 @@
+# File 1 Content
+## Topic 1.1
+Text for topic 1.1
+## Topic 1.2
+Text for topic 1.2

--- a/topics_from_file_to_topic/projectA/guide/guide_content.md
+++ b/topics_from_file_to_topic/projectA/guide/guide_content.md
@@ -1,0 +1,5 @@
+# Guide Content
+## Intro
+Guide intro text
+### Detail
+Detail text

--- a/topics_from_file_to_topic/projectA/notes/notes_content.md
+++ b/topics_from_file_to_topic/projectA/notes/notes_content.md
@@ -1,0 +1,3 @@
+# Notes Content
+## Note A
+Note A text

--- a/topics_from_file_to_topic/projectB/tutorial/tutorial_content.md
+++ b/topics_from_file_to_topic/projectB/tutorial/tutorial_content.md
@@ -1,0 +1,3 @@
+# Tutorial Content
+## Step 1
+Tutorial step 1


### PR DESCRIPTION
This commit refactors `main_splitter.py` to recursively process topic files from a directory structure, mirroring the output format now generated by `File_to_topic.py`.

Key changes:

1.  **Recursive Topic File Discovery**:
    *   `main_splitter.py` now uses `os.walk()` to find all `.md` files (assumed to be topic files) within the given input directory and its subdirectories.
    *   It no longer assumes topic files are only at the top level of the input directory.

2.  **Mirrored Output Structure for Chunks**:
    *   For each topic file found, the script calculates its path relative to the input directory.
    *   The final chunked `.md` files generated from a topic are saved in an output subdirectory that mirrors this relative path and includes a directory named after the topic slug itself.
    *   Example: If `main_splitter.py` input is `topics_dir/projectA/file1/topic_name.md`, chunks are saved to `[output_dir]/projectA/file1/topic_name/chunk_id.md`.

3.  **Processing Logic Refactoring**:
    *   The call to `split_into_topics()` within `main_splitter.py` has been removed, as the script now expects pre-split topic files as input.
    *   The main loop iterates directly over discovered topic files.
    *   `process_topic_text()` is called for each topic file with appropriately adjusted arguments:
        *   `topic_slug` is derived from the topic filename.
        *   `topic_text` is the content of the topic file.
        *   `output_dir` for `process_topic_text` is the specific nested directory for that topic's chunks.
        *   The `original_filename` argument (used for `file_path` metadata in chunks) is now the relative path of the topic file itself (e.g., `projectA/file1/topic_name.md`).

4.  **User Feedback**:
    *   Improved console messages for directory scanning.

This update allows `main_splitter.py` to seamlessly process the structured output of the enhanced `File_to_topic.py`, maintaining a consistent hierarchical organization from the initial large Markdown files down to the final small text chunks.