### PR TITLE
Fix: Ensure unique chunk filenames and preserve small chunks

### DIFF
--- a/embedder/main_splitter.py
+++ b/embedder/main_splitter.py
@@ -151,7 +151,8 @@ def process_topic_text(
                     sec_num = ".".join(str(x) for x in prev_nums)
                 else:
                     sec_num = "1"
-            chunk_id = f"{cluster}_{topic}_sec{sec_num}"
+            # Modified chunk_id to include start line
+            chunk_id = f"{cluster}_{topic}_sec{sec_num}_L{chunk['start_line']}"
 
             # 7d) Build section_hierarchy from headings appearing before this chunk
             ancestors = [h["heading_text"] for h in headings if h["line_no"] <= chunk["start_line"]]
@@ -161,8 +162,9 @@ def process_topic_text(
             keywords = extract_keywords(text, custom_stop)
             description = extract_description(text)
 
+            # Ensure metadata uses the new unique chunk_id
             metadata = {
-                "id": chunk_id,
+                "id": chunk_id, # Updated chunk_id
                 "cluster": cluster,
                 "topic": topic,
                 "title": own_heading,


### PR DESCRIPTION
This commit addresses issues causing missing sections in the final output of the Markdown splitting process.

1.  Modified `main_splitter.py`'s `process_topic_text` function to generate unique filenames for chunks. The `chunk_id` (and thus the filename) now incorporates the chunk's start line number (e.g., `_L{chunk['start_line']}`). This prevents different content segments that fall under the same logical section number from overwriting each other's output files. The `metadata['id']` has also been updated to use this more specific ID.

2.  Ensured that the filter in `main_splitter.py` which previously discarded text chunks smaller than 5 tokens remains commented out. This prevents the loss of valid small text fragments, such as short list items or introductory sentences, which can be generated by the recursive splitting logic in `Marking_splitter.py`.

These changes together should resolve the problem of entire paragraphs and sections going missing from the final chunked output. Extensive logging was also previously added to `Marking_splitter.py` to aid in diagnosing splitting behavior.